### PR TITLE
.github: move some workflows to public

### DIFF
--- a/.github/workflows/sync.ens.yaml
+++ b/.github/workflows/sync.ens.yaml
@@ -17,5 +17,4 @@ jobs:
           dir: 'dirs/exposure-notifications-server'
           dir-format: golang-migrate
           driver: postgres
-          cloud-url: https://gh-api.atlasgo.link
           cloud-public: true

--- a/.github/workflows/sync.harbor.yaml
+++ b/.github/workflows/sync.harbor.yaml
@@ -16,6 +16,5 @@ jobs:
           dir: 'dirs/harbor'
           dir-format: golang-migrate
           driver: postgres
-          cloud-url: https://gh-api.atlasgo.link
           cloud-public: true
           

--- a/.github/workflows/sync.keto.yaml
+++ b/.github/workflows/sync.keto.yaml
@@ -16,5 +16,4 @@ jobs:
           dir: 'dirs/keto'
           dir-format: golang-migrate
           driver: postgres
-          cloud-url: https://gh-api.atlasgo.link
           cloud-public: true

--- a/.github/workflows/sync.marquez.yaml
+++ b/.github/workflows/sync.marquez.yaml
@@ -15,7 +15,6 @@ jobs:
       - uses: ariga/atlas-sync-action@v0
         with:
           dir: 'dirs/marquez'
-          driver: postgres
-          cloud-url: https://gh-api.atlasgo.link
-          cloud-public: true
           dir-format: flyway
+          driver: postgres
+          cloud-public: true

--- a/.github/workflows/sync.rudder.yaml
+++ b/.github/workflows/sync.rudder.yaml
@@ -16,5 +16,4 @@ jobs:
           dir: 'dirs/rudder'
           dir-format: golang-migrate
           driver: postgres
-          cloud-url: https://gh-api.atlasgo.link
           cloud-public: true

--- a/.github/workflows/sync.werft.yaml
+++ b/.github/workflows/sync.werft.yaml
@@ -17,5 +17,4 @@ jobs:
           dir: 'dirs/werft'
           dir-format: golang-migrate
           driver: postgres
-          cloud-url: https://gh-api.atlasgo.link
           cloud-public: true


### PR DESCRIPTION
- Exposure notification Server (https://gh.atlasgo.link/dirs/4294967535)
- Harbor (https://gh.atlasgo.link/dirs/4294967547)
- Keto (https://gh.atlasgo.link/dirs/4294967579)
- Marquez (https://gh.atlasgo.link/dirs/4294967382)
- Rudder (https://gh.atlasgo.link/dirs/4294967392)
- Werft (https://gh.atlasgo.link/dirs/4294967468)