### PR TITLE
.github/workflows: add missing permissions to atlas lint action

### DIFF
--- a/.github/workflows/full.ecommerce.yaml
+++ b/.github/workflows/full.ecommerce.yaml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: write
     services:
       mysql:
         image: mysql:8.0.29


### PR DESCRIPTION
fix this [errors](https://github.com/ariga/atlas-showcase/actions/runs/10760190233/job/29837808760#step:5:14) when atlas lint action tries to comment on a PR

<img width="1377" alt="image" src="https://github.com/user-attachments/assets/112dc871-3049-46ef-9a3e-c5edfb6a7dcf">
